### PR TITLE
A couple small fixes/improvements to the build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION=$(VERSION)
 ARCH=$(ARCH)
 VIRTIO_WIN_DRIVERS_PATH=$(VIRTIO_WIN_DRIVERS_PATH)
 
-NAME=virtio-guest-tools-installer
+NAME=virtio-win-guest-tools-installer
 ARCHIVE=$(NAME)-$(VERSION).tar.gz
 # Location of installed RPMS that we package:
 # ovirt-guest-agent-windows.rpm

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -26,6 +26,10 @@ if ! rpm -q --quiet $PACKAGES ; then
     exit 1
 fi
 
+# Add a /tmp link to the drivers directory, to try and avoid length limitations
+VIRTIO_WIN_DRIVERS_LINK=$(mktemp -t vwi.XXXX)
+ln -sf ${VIRTIO_WIN_DRIVERS_PATH} ${VIRTIO_WIN_DRIVERS_LINK}
+
 # Enable command tracing
 set -x
 
@@ -48,10 +52,11 @@ mv *.tar.gz exported-artifacts/
 
 # Build the installer
 pushd tmp
-make ARCH=x64 VERSION=${VERSION} VIRTIO_WIN_DRIVERS_PATH=${VIRTIO_WIN_DRIVERS_PATH}
+make ARCH=x64 VERSION=${VERSION} VIRTIO_WIN_DRIVERS_PATH=${VIRTIO_WIN_DRIVERS_LINK}
 make clean
-make ARCH=x86 VERSION=${VERSION} VIRTIO_WIN_DRIVERS_PATH=${VIRTIO_WIN_DRIVERS_PATH}
+make ARCH=x86 VERSION=${VERSION} VIRTIO_WIN_DRIVERS_PATH=${VIRTIO_WIN_DRIVERS_LINK}
 
+unlink ${VIRTIO_WIN_DRIVERS_LINK}
 make test
 popd
 


### PR DESCRIPTION
* Name the src archive virtio-win-XXX not virtio-XXX
* Try to work around path lenght limitations by using a temporary symlink