### PR TITLE
test: Fix msi output location

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -3,8 +3,8 @@ import subprocess
 import pytest
 import msi_values
 
-MSIx64_PATH = '../virtio-win-gt-x64.msi'
-MSIx86_PATH = '../virtio-win-gt-x86.msi'
+MSIx64_PATH = '../tmp/virtio-win-gt-x64.msi'
+MSIx86_PATH = '../tmp/virtio-win-gt-x86.msi'
 
 
 def run_command(command):


### PR DESCRIPTION
Via virtio-win-pkg-scripts I'm only seeing .msi files generated
in ./tmp, not the git top directory. I'm not sure if that's intended
or it's some side effect of the way we are building. If it's intended,
this test needs to be adjusted.