### PR TITLE
Remove Start option from virtio-fs service ServiceControl section to …

### DIFF
--- a/virtio-win-drivers-installer/Drivers/viofs/viofs_extras.wxi
+++ b/virtio-win-drivers-installer/Drivers/viofs/viofs_extras.wxi
@@ -32,7 +32,6 @@
             <ServiceControl
                 Id="sc_VirtioFSService_$(var.osShort)_$(var.ISA)"
                 Name="VirtIO-FS Service"
-                Start="install"
                 Stop="both"
                 Remove="uninstall"
                 Wait="yes" />


### PR DESCRIPTION
…prevent

installer from starting the service on install.

Since firtio-fs service depends on winfsp, it fails to start in case
when winfsp was not installed on the system.

Signed-off-by: Vadim Rozenfeld <vrozenfe@redhat.com>