### PR TITLE
Change virtiofs service Name and DisplayName

### DIFF
--- a/virtio-win-drivers-installer/Drivers/viofs/viofs_extras.wxi
+++ b/virtio-win-drivers-installer/Drivers/viofs/viofs_extras.wxi
@@ -21,17 +21,17 @@
                 Source='$(var.virtio_path)\viofs\$(var.osShort)\$(var.ISA)\virtiofs.exe'
                 KeyPath='yes'/>
             <ServiceInstall
-                Id="VirtioFSService_$(var.osShort)_$(var.ISA)"
-                Name="VirtIO-FS Service"
-                DisplayName="VirtioFSService"
-                Description="VirtIO-FS Service"
+                Id="VirtioFsSvc_$(var.osShort)_$(var.ISA)"
+                Name="VirtioFsSvc"
+                DisplayName="VirtIO-FS Service"
+                Description="Enables Windows virtual machines to access directories on the host that have been shared with them using virtiofs."
                 Start="demand"
                 ErrorControl="ignore"
                 Type="ownProcess"
                 Vital="no"/>
             <ServiceControl
-                Id="sc_VirtioFSService_$(var.osShort)_$(var.ISA)"
-                Name="VirtIO-FS Service"
+                Id="sc_VirtioFsSvc_$(var.osShort)_$(var.ISA)"
+                Name="VirtioFsSvc"
                 Stop="both"
                 Remove="uninstall"
                 Wait="yes" />


### PR DESCRIPTION
Fixes #23

Previously we were essentially doing:

  sc create "Virtio FS Service" ... DisplayName=VirtioFsSvc

but now we're essentially doing:

  sc create VirtioFsSvc ... DisplayName="Virtio FS Service"

The previous behavior was confusing because it made all future
interacting with the service (using tools such as `sc`) look like the
service's DisplayName was being specified where the command actually
expects (requires!) the service's Name to be specified.

Note that this commit uses "VirtioFsSvc" as the service Name instead of
"VirtioFSService". That's for consistency with the instructions that
people have been using when following:

  https://virtio-fs.gitlab.io/howto-windows.html

This commit also adds a "Description" field to help people determine
what the service is for when they encounter it in the Services app, for
example.

Signed-off-by: Jonathan Watt <jwatt@jwatt.org>