### PR TITLE
Add dependencies to the VirtioFsSvc service

### DIFF
--- a/virtio-win-drivers-installer/Drivers/viofs/viofs_extras.wxi
+++ b/virtio-win-drivers-installer/Drivers/viofs/viofs_extras.wxi
@@ -25,6 +25,7 @@
                 Name="VirtioFsSvc"
                 DisplayName="VirtIO-FS Service"
                 Description="Enables Windows virtual machines to access directories on the host that have been shared with them using virtiofs."
+                Dependencies="WinFsp.Launcher/VirtioFsDrv"
                 Start="demand"
                 ErrorControl="ignore"
                 Type="ownProcess"


### PR DESCRIPTION
The service has two dependencies (WinFsp.Launcher and VirtioFsDrv) as
noted, for example, at:

https://virtio-fs.gitlab.io/howto-windows.html
https://github.com/virtio-win/kvm-guest-drivers-windows/issues/550#issuecomment-779047192