### PR TITLE
Fix driver upgrade failure when drivers are in use

### DIFF
--- a/src/DrvInst/DrvInstCA/DevProps.cpp
+++ b/src/DrvInst/DrvInstCA/DevProps.cpp
@@ -1203,7 +1203,7 @@ DWORD DevDriver::UnInstallOEMInf()
     else
     {
         pOem = GetStrongName();
-        if (pOem && m_pDiUninstallDriver(NULL, pOem, 0/*DIURFLAG_NO_REMOVE_INF*/, &m_bRebootNeeded))
+        if (pOem && m_pDiUninstallDriver(NULL, pOem, DIURFLAG_NO_REMOVE_INF, &m_bRebootNeeded))
         {
             return NO_ERROR;
         }

--- a/src/DrvInst/DrvInstCA/stdafx.h
+++ b/src/DrvInst/DrvInstCA/stdafx.h
@@ -49,3 +49,10 @@ void LogReport(
 #define WFUNCTION WIDE1(__FUNCTION__)
 
 const wchar_t* GetErrorString(DWORD Err);
+
+// DIURFLAG_NO_REMOVE_INF: Do not remove the INF file from the driver store
+// when uninstalling the driver. This allows the driver to be cleaned up
+// after reboot when it's currently in use.
+#ifndef DIURFLAG_NO_REMOVE_INF
+#define DIURFLAG_NO_REMOVE_INF 0x00000001
+#endif

--- a/src/DrvInst/DrvInstLib/VirtWinDrvExtension.wxs
+++ b/src/DrvInst/DrvInstLib/VirtWinDrvExtension.wxs
@@ -21,7 +21,7 @@
     <CustomAction Id='ProcessDriverPackages'   BinaryKey='DrvInstallDll' DllEntry='ProcessPackages' SuppressModularization='yes' Execute='immediate' />
     <CustomAction Id='InstallDriverPackages'   BinaryKey='DrvInstallDll' DllEntry='InstallPackages' SuppressModularization='yes' Execute='deferred' Impersonate='no' Return='check' />
     <CustomAction Id='RollbackInstall'         BinaryKey='DrvInstallDll' DllEntry='UninstallPackages' SuppressModularization='yes' Execute='rollback' Impersonate='no' />
-    <CustomAction Id='UninstallDriverPackages' BinaryKey='DrvInstallDll' DllEntry='UninstallPackages' SuppressModularization='yes' Execute='deferred' Impersonate='no' Return='check' />
+    <CustomAction Id='UninstallDriverPackages' BinaryKey='DrvInstallDll' DllEntry='UninstallPackages' SuppressModularization='yes' Execute='deferred' Impersonate='no' Return='ignore' />
     <CustomAction Id='RollbackUninstall'       BinaryKey='DrvInstallDll' DllEntry='InstallPackages' SuppressModularization='yes' Execute='rollback' Impersonate='no' />
 
   </Fragment>

--- a/virtio-win-drivers-installer/installer.wxs
+++ b/virtio-win-drivers-installer/installer.wxs
@@ -20,9 +20,9 @@
             <PropertyRef Id="Set_ProductName" />
             <PropertyRef Id="Set_CurrentBuildNumber" />
             <PropertyRef Id="Set_Old_WGT_props" />
-            <MajorUpgrade 
+            <MajorUpgrade
                   DowngradeErrorMessage="A newer version of [ProductName] is already installed."
-                  Schedule="afterInstallInitialize" />
+                  Schedule="afterInstallExecute" />
             <UIRef Id="WixUI_FeatureTree" />
             <WixVariable Id="WixUIBannerBmp" Value="graphics/horizontal_banner.bmp" />
             <WixVariable Id="WixUIDialogBmp" Value="graphics/background.bmp" />


### PR DESCRIPTION
Problem: Upgrading virtio-win drivers fails with error 1603 when drivers are currently in use (e.g., viostor as boot disk). The UninstallDriverPackages custom action fails because it cannot uninstall drivers that are actively being used by the system.

Changes:
- Change MajorUpgrade Schedule from "afterInstallInitialize" to "afterInstallExecute" to install new files before removing old version
- Change UninstallDriverPackages Return from "check" to "ignore" so uninstall failures don't block the entire installation
- Enable DIURFLAG_NO_REMOVE_INF flag to defer INF cleanup until reboot

The upgrade now completes successfully with a reboot, allowing Windows to clean up old drivers after restart.