### PR TITLE
Fix GUI Change/Modify not installing newly selected features

### DIFF
--- a/virtio-win-drivers-installer/properties.wxs
+++ b/virtio-win-drivers-installer/properties.wxs
@@ -36,7 +36,7 @@
     <!-- Query the ProductName registry value to detect os version -->
     <Fragment>
         <Property Id="Set_ProductName" Value="1" />
-        <Property Id="REGISTRY_PRODUCT_NAME">
+        <Property Id="REGISTRY_PRODUCT_NAME" Secure="yes">
             <RegistrySearch Id="ProductNameSearch"
                 Root="HKLM"
                 Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"
@@ -47,7 +47,7 @@
     <!-- Query the ProductName registry value to detect os version -->
     <Fragment>
         <Property Id="Set_CurrentBuildNumber" Value="1" />
-        <Property Id="REGISTRY_CURRENT_BUILD_NUMBER">
+        <Property Id="REGISTRY_CURRENT_BUILD_NUMBER" Secure="yes">
             <RegistrySearch Id="CurrentBuildNumberSearch"
                 Root="HKLM"
                 Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"


### PR DESCRIPTION
## Context

This bug was discovered while working on #88 (Add VioGpu Resolution Service). Because the new service feature defaults to unchecked (`Level='1001'`), adding it via Change/Modify in the GUI exposed a pre-existing property-passing issue that affects all features.

## Summary

Mark `REGISTRY_PRODUCT_NAME` and `REGISTRY_CURRENT_BUILD_NUMBER` as `Secure` properties so they are passed from the client-side (UI) to the server-side (elevated install) during maintenance mode.

## Problem

When a user runs the installer in maintenance mode (Change/Modify from Add/Remove Programs), selects a previously uninstalled feature in the feature tree, and clicks Install, the feature appears installed in the UI but the files and services are never actually deployed.

The MSI verbose log shows:
```
Ignoring disallowed property REGISTRY_PRODUCT_NAME
Ignoring disallowed property REGISTRY_CURRENT_BUILD_NUMBER
```

And for affected components:
```
Feature: FE_xxx; Installed: Absent; Request: Local; Action: Local    <-- correct
Component: CMP_xxx; Installed: Absent; Request: Local; Action: Null  <-- wrong, should be Local
```

## Root Cause

`REGISTRY_PRODUCT_NAME` and `REGISTRY_CURRENT_BUILD_NUMBER` are used in component `<Condition>` elements to match the correct OS variant. During a GUI maintenance install, the MSI client-side (UI process) passes properties to the server-side (elevated install process). Properties not marked as `Secure` are discarded by the server-side for security reasons.

During first-time install this is not a problem because the server-side re-executes `AppSearch` and reads the registry values directly. But during maintenance mode, `AppSearch` is skipped on the server-side (already done on client-side), and the non-secure properties are lost — causing all component conditions to evaluate to false.

This bug affects all features but was never noticed because all driver features default to Level=1 (selected), so users never needed to add a feature via Change/Modify.

## Fix

Add `Secure="yes"` to both property definitions, allowing them to pass through to the server-side during maintenance installs.

## Testing

Tested on Windows 11 (build 26100):
- Fresh install with a feature unchecked, then Change/Modify to add it back: files installed correctly
- Change/Modify to remove a feature: files removed correctly