### PR TITLE
RHEL-144824: Add WiX 3.11 Visual Studio 2022 project files for installer build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,16 @@ vwi/
 spice/
 qemu-ga/
 */__pycache__
+
+# Visual Studio build artifacts
+bin/
+obj/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+.vs/
+
+# Generated from .in templates at build time
+virtio-win-drivers-installer/constants.wxi
+virtio-win-installers-bundler/Bundle.wxs

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ clean:
 	-e "s|@@SPICE_DRIVER_86_MSI_PATH@@|${SPICE_DRIVER_86_MSI_PATH}|g" \
 	-e "s|@@QEMU_GA_64_MSI_PATH@@|${QEMU_GA_64_MSI_PATH}|g" \
 	-e "s|@@QEMU_GA_86_MSI_PATH@@|${QEMU_GA_86_MSI_PATH}|g" \
+	-e "s|@@VIRTIO_WIN_GT_X64_MSI_PATH@@|../virtio-win-drivers-installer/virtio-win-gt-x64.msi|g" \
+	-e "s|@@VIRTIO_WIN_GT_X86_MSI_PATH@@|../virtio-win-drivers-installer/virtio-win-gt-x86.msi|g" \
 	-e "s|@@VERSION@@|${VERSION}|g" \
 	$< > $@
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ You can get it by:
 
 3. The build artifacts which are 2 msis (x64, x86) and one .exe file will be on the exported artifacts directory, which was created during the build process.
 
+### Building with Visual Studio 2022:
+
+#### Prerequisites:
+
+1. [Visual Studio 2022](https://visualstudio.microsoft.com/)
+2. [WiX Toolset v3.11](https://github.com/wixtoolset/wix3/releases)
+3. [WiX Toolset Visual Studio 2022 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2022Extension)
+4. Virtio-win drivers (extracted from the virtio-win ISO)
+
+#### Building from Visual Studio:
+
+1. Open `VirtioWinInstaller.sln` in Visual Studio 2022.
+
+2. Edit the default driver path in `virtio-win-drivers-installer\virtio-win-drivers-installer.wixproj` - set `VirtioWinDriversPath` to the location of your extracted virtio-win ISO content (see [Prerequisites](#prerequsits) for the expected driver directory structure).
+
+3. Select the desired platform (x64 or x86) from the toolbar.
+
+4. Build the solution (Ctrl+Shift+B).
+
+5. The MSI output will be in `virtio-win-drivers-installer\bin\<platform>\<configuration>\`.
+
+6. The Bundle (.exe) requires additional MSI paths for Spice and QEMU Guest Agent. Edit the default paths in `virtio-win-installers-bundler\virtio-win-installers-bundler.wixproj` or pass them via command line using `msbuild /p:SpiceDriver64MsiPath=... /p:QemuGa64MsiPath=...` etc. **Note:** To build the Bundle, you must build the solution for both x64 and x86 platforms first, as the bundle includes both installers.
+
+#### Build outputs:
+
+- MSI installers: `virtio-win-drivers-installer\bin\<platform>\<configuration>\virtio-win-gt-<platform>.msi`
+- Bundle (.exe): `virtio-win-installers-bundler\bin\<platform>\<configuration>\virtio-win-guest-tools.exe`
+
 ## Contributions:
 
 Contributions are more than welcome, please fork the repository and create a PR.

--- a/VirtioWinInstaller.sln
+++ b/VirtioWinInstaller.sln
@@ -1,0 +1,41 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "virtio-win-drivers-installer", "virtio-win-drivers-installer\virtio-win-drivers-installer.wixproj", "{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}"
+EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "virtio-win-installers-bundler", "virtio-win-installers-bundler\virtio-win-installers-bundler.wixproj", "{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5} = {8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Debug|x64.ActiveCfg = Debug|x64
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Debug|x64.Build.0 = Debug|x64
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Debug|x86.ActiveCfg = Debug|x86
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Debug|x86.Build.0 = Debug|x86
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Release|x64.ActiveCfg = Release|x64
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Release|x64.Build.0 = Release|x64
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Release|x86.ActiveCfg = Release|x86
+		{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}.Release|x86.Build.0 = Release|x86
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Debug|x86.ActiveCfg = Debug|x86
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Debug|x86.Build.0 = Debug|x86
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Release|x64.Build.0 = Release|x64
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Release|x86.ActiveCfg = Release|x86
+		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/virtio-win-drivers-installer/virtio-win-drivers-installer.wixproj
+++ b/virtio-win-drivers-installer/virtio-win-drivers-installer.wixproj
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled;GenerateConstants" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>{8B3D5580-3C4F-4D3B-B247-9F6BE6B3E2A5}</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>virtio-win-gt-$(Platform)</OutputName>
+    <OutputType>Package</OutputType>
+    <Cultures>en-us</Cultures>
+    <SuppressValidation>true</SuppressValidation>
+  </PropertyGroup>
+
+  <!--
+    Configurable properties - override at build time:
+      msbuild /p:InstallerVersion=1.2.3.0 /p:VirtioWinDriversPath=C:\path\to\drivers
+    Or edit the defaults below for local development.
+  -->
+  <PropertyGroup>
+    <InstallerVersion Condition=" '$(InstallerVersion)' == '' ">0.1.0.0</InstallerVersion>
+    <VirtioWinDriversPath Condition=" '$(VirtioWinDriversPath)' == '' ">C:\virtio-win-drivers</VirtioWinDriversPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="installer.wxs" />
+    <Compile Include="properties.wxs" />
+    <Compile Include="features.wxs" />
+    <Compile Include="directories.wxs" />
+    <Compile Include="installSequence.wxs" />
+    <Compile Include="Drivers\Balloon\balloon.wxs" />
+    <Compile Include="Drivers\NetKVM\netkvm.wxs" />
+    <Compile Include="Drivers\pvpanic\pvpanic.wxs" />
+    <Compile Include="Drivers\fwcfg\fwcfg.wxs" />
+    <Compile Include="Drivers\qemupciserial\qemupciserial.wxs" />
+    <Compile Include="Drivers\vioinput\vioinput.wxs" />
+    <Compile Include="Drivers\viorng\viorng.wxs" />
+    <Compile Include="Drivers\vioscsi\vioscsi.wxs" />
+    <Compile Include="Drivers\vioserial\vioserial.wxs" />
+    <Compile Include="Drivers\viostor\viostor.wxs" />
+    <Compile Include="Drivers\viofs\viofs.wxs" />
+    <Compile Include="Drivers\viogpudo\viogpudo.wxs" />
+    <Compile Include="Drivers\viomem\viomem.wxs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="constants.wxi.in" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <WixExtension Include="WixUIExtension">
+      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
+      <Name>WixUIExtension</Name>
+    </WixExtension>
+    <WixExtension Include="WixUtilExtension">
+      <HintPath>$(WixExtDir)\WixUtilExtension.dll</HintPath>
+      <Name>WixUtilExtension</Name>
+    </WixExtension>
+    <WixExtension Include="DrvInstExt">
+      <HintPath>..\Libraries\$(Platform)\DrvInstExt.dll</HintPath>
+      <Name>DrvInstExt</Name>
+    </WixExtension>
+  </ItemGroup>
+
+  <!--
+    Pre-build: generate constants.wxi from constants.wxi.in template.
+    Replaces all @@PLACEHOLDER@@ tokens with MSBuild property values.
+  -->
+  <Target Name="GenerateConstants">
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;(Get-Content -Path '$(MSBuildProjectDirectory)\constants.wxi.in' -Raw).Replace('@@VERSION@@', $env:INSTALLER_VERSION).Replace('@@VIRTIO-WIN-PATH@@', $env:VIRTIO_WIN_DRIVERS_PATH) | Set-Content -Path '$(MSBuildProjectDirectory)\constants.wxi' -Encoding UTF8&quot;"
+          EnvironmentVariables="INSTALLER_VERSION=$(InstallerVersion);VIRTIO_WIN_DRIVERS_PATH=$(VirtioWinDriversPath)" />
+  </Target>
+
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 build tools must be installed to build this project. To download the WiX Toolset, see https://github.com/wixtoolset/wix3/releases" />
+  </Target>
+</Project>

--- a/virtio-win-installers-bundler/Bundle.wxs.in
+++ b/virtio-win-installers-bundler/Bundle.wxs.in
@@ -18,14 +18,14 @@
     </BootstrapperApplicationRef>
 		<Chain>
              <MsiPackage
-                SourceFile="../virtio-win-drivers-installer/virtio-win-gt-x64.msi"
+                SourceFile="@@VIRTIO_WIN_GT_X64_MSI_PATH@@"
                 InstallCondition="VersionNT64"
                 EnableFeatureSelection="yes"
                 DisplayInternalUI="yes"
                 DisplayName="virtio-win-drivers"
                 Description="MSI to install virtio-win drivers for x64 systems"/>
              <MsiPackage
-                SourceFile="../virtio-win-drivers-installer/virtio-win-gt-x86.msi"
+                SourceFile="@@VIRTIO_WIN_GT_X86_MSI_PATH@@"
                 InstallCondition="NOT VersionNT64"
                 EnableFeatureSelection="yes"
                 DisplayInternalUI="yes"

--- a/virtio-win-installers-bundler/virtio-win-installers-bundler.wixproj
+++ b/virtio-win-installers-bundler/virtio-win-installers-bundler.wixproj
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled;GenerateBundle" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>virtio-win-guest-tools</OutputName>
+    <OutputType>Bundle</OutputType>
+    <SuppressValidation>true</SuppressValidation>
+  </PropertyGroup>
+
+  <!--
+    Configurable properties - override at build time:
+      msbuild /p:InstallerVersion=1.2.3.0 /p:SpiceDriver64MsiPath=C:\path\to\spice-driver-x64.msi ...
+    Or edit the defaults below for local development.
+  -->
+  <PropertyGroup>
+    <InstallerVersion Condition=" '$(InstallerVersion)' == '' ">0.1.0.0</InstallerVersion>
+    <SpiceDriver64MsiPath Condition=" '$(SpiceDriver64MsiPath)' == '' ">C:\msi\spice-driver-x64.msi</SpiceDriver64MsiPath>
+    <SpiceDriver86MsiPath Condition=" '$(SpiceDriver86MsiPath)' == '' ">C:\msi\spice-driver-x86.msi</SpiceDriver86MsiPath>
+    <SpiceVdagent64MsiPath Condition=" '$(SpiceVdagent64MsiPath)' == '' ">C:\msi\spice-vdagent-x64.msi</SpiceVdagent64MsiPath>
+    <SpiceVdagent86MsiPath Condition=" '$(SpiceVdagent86MsiPath)' == '' ">C:\msi\spice-vdagent-x86.msi</SpiceVdagent86MsiPath>
+    <QemuGa64MsiPath Condition=" '$(QemuGa64MsiPath)' == '' ">C:\msi\qemu-ga-x64.msi</QemuGa64MsiPath>
+    <QemuGa86MsiPath Condition=" '$(QemuGa86MsiPath)' == '' ">C:\msi\qemu-ga-x86.msi</QemuGa86MsiPath>
+    <VirtioWinGtX64MsiPath Condition=" '$(VirtioWinGtX64MsiPath)' == '' ">$(MSBuildThisFileDirectory)..\virtio-win-drivers-installer\bin\x64\$(Configuration)\virtio-win-gt-x64.msi</VirtioWinGtX64MsiPath>
+    <VirtioWinGtX86MsiPath Condition=" '$(VirtioWinGtX86MsiPath)' == '' ">$(MSBuildThisFileDirectory)..\virtio-win-drivers-installer\bin\x86\$(Configuration)\virtio-win-gt-x86.msi</VirtioWinGtX86MsiPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Bundle.wxs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Bundle.wxs.in" />
+    <Content Include="Resources\Theme.xml" />
+    <Content Include="Resources\Theme.wxl" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <WixExtension Include="WixBalExtension">
+      <HintPath>$(WixExtDir)\WixBalExtension.dll</HintPath>
+      <Name>WixBalExtension</Name>
+    </WixExtension>
+  </ItemGroup>
+
+  <!--
+    Pre-build: generate Bundle.wxs from Bundle.wxs.in template.
+    Replaces all @@PLACEHOLDER@@ tokens with MSBuild property values.
+  -->
+  <Target Name="GenerateBundle">
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;(Get-Content -Path '$(MSBuildProjectDirectory)\Bundle.wxs.in' -Raw).Replace('@@VERSION@@', $env:INSTALLER_VERSION).Replace('@@SPICE_DRIVER_64_MSI_PATH@@', $env:SPICE_DRIVER_64).Replace('@@SPICE_DRIVER_86_MSI_PATH@@', $env:SPICE_DRIVER_86).Replace('@@SPICE_VDAGENT_64_MSI_PATH@@', $env:SPICE_VDAGENT_64).Replace('@@SPICE_VDAGENT_86_MSI_PATH@@', $env:SPICE_VDAGENT_86).Replace('@@QEMU_GA_64_MSI_PATH@@', $env:QEMU_GA_64).Replace('@@QEMU_GA_86_MSI_PATH@@', $env:QEMU_GA_86).Replace('@@VIRTIO_WIN_GT_X64_MSI_PATH@@', $env:VIRTIO_GT_X64).Replace('@@VIRTIO_WIN_GT_X86_MSI_PATH@@', $env:VIRTIO_GT_X86) | Set-Content -Path '$(MSBuildProjectDirectory)\Bundle.wxs' -Encoding UTF8&quot;"
+          EnvironmentVariables="INSTALLER_VERSION=$(InstallerVersion);SPICE_DRIVER_64=$(SpiceDriver64MsiPath);SPICE_DRIVER_86=$(SpiceDriver86MsiPath);SPICE_VDAGENT_64=$(SpiceVdagent64MsiPath);SPICE_VDAGENT_86=$(SpiceVdagent86MsiPath);QEMU_GA_64=$(QemuGa64MsiPath);QEMU_GA_86=$(QemuGa86MsiPath);VIRTIO_GT_X64=$(VirtioWinGtX64MsiPath);VIRTIO_GT_X86=$(VirtioWinGtX86MsiPath)" />
+  </Target>
+
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 build tools must be installed to build this project. To download the WiX Toolset, see https://github.com/wixtoolset/wix3/releases" />
+  </Target>
+</Project>


### PR DESCRIPTION
Add Visual Studio 2022 solution and WiX 3.11 project files to enable building the virtio-win drivers MSI installer and Bundle (.exe) natively on Windows.

- VirtioWinInstaller.sln: VS solution with build order dependency
- virtio-win-drivers-installer.wixproj: WiX project for the drivers MSI
- virtio-win-installers-bundler.wixproj: WiX project for the Bundle (.exe)