### PR TITLE
Add retry logic to NIC config restore after driver update

### DIFF
--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -332,7 +332,7 @@ bool ConfigRead::EnableStatic(bool ipv4)
         SAFEARRAY* sa1 = nullptr;
         SAFEARRAY* sa2 = nullptr;
         if (BuildSafeArrayFromVector(&sa1, ipv4 ? ipv4_addr : ipv6_addr) &&
-            BuildSafeArrayFromVector(&sa2, ipv4 ? ipv4_subnet : ipv4_subnet))
+            BuildSafeArrayFromVector(&sa2, ipv4 ? ipv4_subnet : ipv6_subnet))
         {
             CComVariant var1;
             var1.vt = VT_ARRAY | VT_BSTR;

--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -105,6 +105,7 @@ bool ConfigWrite::Run()
                 cf->WriteLine(INTEGER_FORMAT, DNSWINSRES, VT_BOOL, nac->GetBoolProperty(DNSWINSRES));
                 cf->WriteLine(STRING_FORMAT, DNSSRCHORD, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(DNSSRCHORD).c_str());
                 cf->WriteLine(INTEGER_FORMAT, INDX, VT_I4, nac->GetIntProperty(INDX));
+                // ServiceName must be last: ConfigRead::Run() uses it as the adapter block boundary
                 cf->WriteLine(STRING_FORMAT, SRVSNAME, VT_BSTR, srvname.c_str());
             }
         }
@@ -115,13 +116,6 @@ bool ConfigWrite::Run()
 
 ConfigRead::ConfigRead(const PCWSTR filename) : Config(filename)
 {
-    dhcp_en = false;
-    ip_en = false;
-    ip_filt_sec_en = false;
-    dns_for_wins_res_en = false;
-
-    ip_conn_metr = 0;
-    index = 0;
 }
 
 bool ConfigRead::IsValidIPv4Address(std::wstring const& address)
@@ -162,11 +156,11 @@ bool ConfigRead::ProcessInteger(std::vector<std::wstring>& vector)
 
     if (method == IPCONMET)
     {
-        ip_conn_metr = _wtoi(vector[2].c_str());
+        cur.ip_conn_metr = _wtoi(vector[2].c_str());
     }
     else if (method == INDX)
     {
-        index = _wtoi(vector[2].c_str());
+        cur.index = _wtoi(vector[2].c_str());
     }
     else
     {
@@ -182,23 +176,23 @@ bool ConfigRead::ProcessString(std::vector<std::wstring>& vector)
 
     if (method == MACADDR)
     {
-        mac_addr = vector[2].c_str();
+        cur.mac_addr = vector[2].c_str();
     }
     else if (method == DESCR)
     {
-        descr = vector[2].c_str();
+        cur.descr = vector[2].c_str();
     }
     else if (method == DNSDOM)
     {
-        dns_dom = vector[2].c_str();
+        cur.dns_dom = vector[2].c_str();
     }
     else if (method == SRVSNAME)
     {
-        srvc_name = vector[2].c_str();
+        cur.srvc_name = vector[2].c_str();
     }
     else if (method == DNSHOSTNAME)
     {
-        dns_host_name = vector[2].c_str();
+        cur.dns_host_name = vector[2].c_str();
     }
     else
     {
@@ -214,19 +208,19 @@ bool ConfigRead::ProcessBoolean(std::vector<std::wstring>& vector)
 
     if (method == DHCPEN)
     {
-        dhcp_en = !!(_wtoi(vector[2].c_str()));
+        cur.dhcp_en = !!(_wtoi(vector[2].c_str()));
     }
     else if (method == IPEN)
     {
-        ip_en = !!(_wtoi(vector[2].c_str()));
+        cur.ip_en = !!(_wtoi(vector[2].c_str()));
     }
     else if (method == IPFLTSECEN)
     {
-        ip_filt_sec_en = !!(_wtoi(vector[2].c_str()));
+        cur.ip_filt_sec_en = !!(_wtoi(vector[2].c_str()));
     }
     else if (method == DNSWINSRES)
     {
-        dns_for_wins_res_en = !!(_wtoi(vector[2].c_str()));
+        cur.dns_for_wins_res_en = !!(_wtoi(vector[2].c_str()));
     }
     else
     {
@@ -242,26 +236,26 @@ bool ConfigRead::ProcessArrayOfStrings(std::vector<std::wstring>& vector)
 
     if (method == IPADDR)
     {
-        ipv4_addr = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv4);
-        ipv6_addr = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv6);
+        cur.ipv4_addr = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv4);
+        cur.ipv6_addr = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv6);
     }
     else if (method == IPSUBNET)
     {
-        ipv4_subnet = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv4);
-        ipv6_subnet = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv6);
+        cur.ipv4_subnet = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv4);
+        cur.ipv6_subnet = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv6);
     }
     else if (method == DEFIPGW)
     {
-        ipv4_def_gw = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv4);
-        ipv6_def_gw = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv6);
+        cur.ipv4_def_gw = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv4);
+        cur.ipv6_def_gw = SplitStringAsVector(vector[2], STRING_DELIM, SplitType::Ipv6);
     }
     else if (method == DNSDMSUFSRCHORD)
     {
-        dns_dom_suff_srch_ord = SplitStringAsVector(vector[2], STRING_DELIM);
+        cur.dns_dom_suff_srch_ord = SplitStringAsVector(vector[2], STRING_DELIM);
     }
     else if (method == DNSSRCHORD)
     {
-        dns_serv_srch_ord = SplitStringAsVector(vector[2], STRING_DELIM);
+        cur.dns_serv_srch_ord = SplitStringAsVector(vector[2], STRING_DELIM);
     }
     else
     {
@@ -275,6 +269,10 @@ bool ConfigRead::ProcessParametesAsVector(std::vector<std::wstring>& vector)
 {
     assert(vector.size() == 3);
     bool res = false;
+
+    if (vector.size() != 3)
+        return res;
+
     int type = _wtoi(vector[1].c_str());
 
     switch (type)
@@ -323,7 +321,7 @@ bool ConfigRead::BuildSafeArrayFromVector(SAFEARRAY** sa, std::vector<std::wstri
     return false;
 }
 
-bool ConfigRead::EnableStatic(bool ipv4)
+bool ConfigRead::EnableStatic(AdapterConfig const& cfg, bool ipv4)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
 
@@ -331,8 +329,8 @@ bool ConfigRead::EnableStatic(bool ipv4)
     {
         SAFEARRAY* sa1 = nullptr;
         SAFEARRAY* sa2 = nullptr;
-        if (BuildSafeArrayFromVector(&sa1, ipv4 ? ipv4_addr : ipv6_addr) &&
-            BuildSafeArrayFromVector(&sa2, ipv4 ? ipv4_subnet : ipv6_subnet))
+        if (BuildSafeArrayFromVector(&sa1, ipv4 ? cfg.ipv4_addr : cfg.ipv6_addr) &&
+            BuildSafeArrayFromVector(&sa2, ipv4 ? cfg.ipv4_subnet : cfg.ipv6_subnet))
         {
             CComVariant var1;
             var1.vt = VT_ARRAY | VT_BSTR;
@@ -358,14 +356,14 @@ bool ConfigRead::EnableStatic(bool ipv4)
     return false;
 }
 
-bool ConfigRead::SetDNSServer(void)
+bool ConfigRead::SetDNSServer(AdapterConfig const& cfg)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
 
     if (nac->GetMethod(SETDNSSRCORD_METHOD, pInInstClass))
     {
         SAFEARRAY* sa1 = nullptr;
-        if (BuildSafeArrayFromVector(&sa1, dns_serv_srch_ord))
+        if (BuildSafeArrayFromVector(&sa1, cfg.dns_serv_srch_ord))
         {
             CComVariant var1;
             var1.vt = VT_ARRAY | VT_BSTR;
@@ -388,7 +386,7 @@ bool ConfigRead::SetDNSServer(void)
     return false;
 }
 
-bool ConfigRead::EnableDNS(void)
+bool ConfigRead::EnableDNS(AdapterConfig const& cfg)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
 
@@ -396,16 +394,16 @@ bool ConfigRead::EnableDNS(void)
     {
         SAFEARRAY* sa1 = nullptr;
         SAFEARRAY* sa2 = nullptr;
-        if (BuildSafeArrayFromVector(&sa1, dns_serv_srch_ord) &&
-            BuildSafeArrayFromVector(&sa2, dns_dom_suff_srch_ord))
+        if (BuildSafeArrayFromVector(&sa1, cfg.dns_serv_srch_ord) &&
+            BuildSafeArrayFromVector(&sa2, cfg.dns_dom_suff_srch_ord))
         {
             CComVariant var1;
             var1.vt = VT_BSTR;
-            var1.bstrVal = (BSTR)bstr_t(dns_host_name.c_str());
+            var1.bstrVal = (BSTR)bstr_t(cfg.dns_host_name.c_str());
 
             CComVariant var2;
             var2.vt = VT_BSTR;
-            var2.bstrVal = (BSTR)bstr_t(dns_dom.c_str());
+            var2.bstrVal = (BSTR)bstr_t(cfg.dns_dom.c_str());
 
             CComVariant var3;
             var3.vt = VT_ARRAY | VT_BSTR;
@@ -434,14 +432,14 @@ bool ConfigRead::EnableDNS(void)
     return false;
 }
 
-bool ConfigRead::SetGateWays(bool ipv4)
+bool ConfigRead::SetGateWays(AdapterConfig const& cfg, bool ipv4)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
 
     if (nac->GetMethod(SETGW_METHOD, pInInstClass))
     {
         SAFEARRAY* sa1 = nullptr;
-        if (BuildSafeArrayFromVector(&sa1, ipv4 ? ipv4_def_gw : ipv6_def_gw))
+        if (BuildSafeArrayFromVector(&sa1, ipv4 ? cfg.ipv4_def_gw : cfg.ipv6_def_gw))
         {
             CComVariant var1;
             var1.vt = VT_ARRAY | VT_BSTR;
@@ -464,38 +462,38 @@ bool ConfigRead::SetGateWays(bool ipv4)
     return false;
 }
 
-bool ConfigRead::RestoreConfig()
+bool ConfigRead::RestoreAdapter(AdapterConfig const& cfg)
 {
     if (nac->GetInstances())
     {
         while (nac->MoveNext())
         {
             std::wstring mac = nac->GetStringProperty(MACADDR);
-            LogReport(S_OK, L"macs %ws <--> %ws.", mac.c_str(), mac_addr.c_str());
-            if (nac->GetStringProperty(MACADDR) == mac_addr &&
-                nac->GetStringProperty(SRVSNAME) == srvc_name)
+            LogReport(S_OK, L"macs %ws <--> %ws.", mac.c_str(), cfg.mac_addr.c_str());
+            if (mac == cfg.mac_addr &&
+                nac->GetStringProperty(SRVSNAME) == cfg.srvc_name)
             {
-                if (!EnableStatic(true))
+                if (!EnableStatic(cfg, true))
                 {
                     LogReport(S_OK, L"EnableStatic IPv4 failed");
                 }
-                if (!EnableStatic(false))
+                if (!EnableStatic(cfg, false))
                 {
                     LogReport(S_OK, L"EnableStatic IPv6 failed");
                 }
-                if (!SetDNSServer())
+                if (!SetDNSServer(cfg))
                 {
                     LogReport(S_OK, L"SetDNSServer failed");
                 }
-                if (!SetGateWays(true))
+                if (!SetGateWays(cfg, true))
                 {
                     LogReport(S_OK, L"SetGateWays IPv4 failed");
                 }
-                if (!SetGateWays(false))
+                if (!SetGateWays(cfg, false))
                 {
                     LogReport(S_OK, L"SetGateWays IPv6 failed");
                 }
-                if (!EnableDNS())
+                if (!EnableDNS(cfg))
                 {
                     LogReport(S_OK, L"EnableDNS failed");
                 }
@@ -515,9 +513,17 @@ bool ConfigRead::Run()
     {
         std::vector<std::wstring> params;
         params = SplitStringAsVector(line, PARAMS_DELIM);
-        ProcessParametesAsVector(params);
+        if (ProcessParametesAsVector(params) == true && params[0] == SRVSNAME)
+        {
+            adapters.push_back(cur);
+            cur = AdapterConfig();
+        }
     }
-    RestoreConfig();
+
+    for (size_t i = 0; i < adapters.size(); i++)
+    {
+        RestoreAdapter(adapters[i]);
+    }
 
     return true;
 }

--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -28,6 +28,11 @@
  */
 #include "stdafx.h"
 #include "ConfigClass.h"
+#include <set>
+
+/* Max time waiting for NIC re-enumeration: 5 x 3s = 15s */
+static const int RESTORE_MAX_RETRIES = 5;
+static const DWORD RESTORE_RETRY_DELAY_MS = 3000;
 
 Config::Config(const PCWSTR filename)
 {
@@ -462,47 +467,38 @@ bool ConfigRead::SetGateWays(AdapterConfig const& cfg, bool ipv4)
     return false;
 }
 
-bool ConfigRead::RestoreAdapter(AdapterConfig const& cfg)
+/*
+ * Apply saved network configuration to an adapter that has already been
+ * matched by MAC address. The caller must position the WMI enumerator
+ * on the correct adapter instance before calling this.
+ */
+bool ConfigRead::ApplyAdapterConfig(AdapterConfig const& cfg)
 {
-    if (nac->GetInstances())
+    if (!EnableStatic(cfg, true))
     {
-        while (nac->MoveNext())
-        {
-            std::wstring mac = nac->GetStringProperty(MACADDR);
-            LogReport(S_OK, L"macs %ws <--> %ws.", mac.c_str(), cfg.mac_addr.c_str());
-            if (mac == cfg.mac_addr &&
-                nac->GetStringProperty(SRVSNAME) == cfg.srvc_name)
-            {
-                if (!EnableStatic(cfg, true))
-                {
-                    LogReport(S_OK, L"EnableStatic IPv4 failed");
-                }
-                if (!EnableStatic(cfg, false))
-                {
-                    LogReport(S_OK, L"EnableStatic IPv6 failed");
-                }
-                if (!SetDNSServer(cfg))
-                {
-                    LogReport(S_OK, L"SetDNSServer failed");
-                }
-                if (!SetGateWays(cfg, true))
-                {
-                    LogReport(S_OK, L"SetGateWays IPv4 failed");
-                }
-                if (!SetGateWays(cfg, false))
-                {
-                    LogReport(S_OK, L"SetGateWays IPv6 failed");
-                }
-                if (!EnableDNS(cfg))
-                {
-                    LogReport(S_OK, L"EnableDNS failed");
-                }
-                return true;
-            }
-        }
+        LogReport(S_OK, L"EnableStatic IPv4 failed");
     }
-
-    return false;
+    if (!EnableStatic(cfg, false))
+    {
+        LogReport(S_OK, L"EnableStatic IPv6 failed");
+    }
+    if (!SetDNSServer(cfg))
+    {
+        LogReport(S_OK, L"SetDNSServer failed");
+    }
+    if (!SetGateWays(cfg, true))
+    {
+        LogReport(S_OK, L"SetGateWays IPv4 failed");
+    }
+    if (!SetGateWays(cfg, false))
+    {
+        LogReport(S_OK, L"SetGateWays IPv6 failed");
+    }
+    if (!EnableDNS(cfg))
+    {
+        LogReport(S_OK, L"EnableDNS failed");
+    }
+    return true;
 }
 
 bool ConfigRead::Run()
@@ -520,9 +516,71 @@ bool ConfigRead::Run()
         }
     }
 
+    LogReport(S_OK, L"Parsed %zu adapter(s) from config file", adapters.size());
+
+    /*
+     * Use a set of indices to track which adapters have been restored.
+     * set::count() is always safe regardless of the value passed — avoids
+     * the risk of out-of-bounds access that a parallel bool vector would
+     * have if the two collections ever got out of sync.
+     */
+    std::set<size_t> restored;
+
+    /*
+     * After a driver update the NIC re-enumerates asynchronously via PnP.
+     * The adapter may not be visible in WMI immediately. Retry the WMI
+     * query up to RESTORE_MAX_RETRIES times, waiting RESTORE_RETRY_DELAY_MS
+     * between attempts. Each attempt scans all WMI results once and matches
+     * against all adapters not yet restored.
+     */
+    for (int attempt = 1;
+         attempt <= RESTORE_MAX_RETRIES && restored.size() < adapters.size();
+         attempt++)
+    {
+        if (attempt > 1)
+        {
+            LogReport(S_OK, L"Attempt %d/%d: %zu adapter(s) pending, "
+                     L"waiting %lu ms for device re-enumeration",
+                     attempt, RESTORE_MAX_RETRIES,
+                     adapters.size() - restored.size(),
+                     RESTORE_RETRY_DELAY_MS);
+            Sleep(RESTORE_RETRY_DELAY_MS);
+        }
+
+        if (!nac->GetInstances())
+            continue;
+
+        while (nac->MoveNext())
+        {
+            std::wstring mac = nac->GetStringProperty(MACADDR);
+            std::wstring svc = nac->GetStringProperty(SRVSNAME);
+
+            for (size_t i = 0; i < adapters.size(); i++)
+            {
+                if (restored.count(i))
+                    continue;
+                if (mac == adapters[i].mac_addr && svc == adapters[i].srvc_name)
+                {
+                    LogReport(S_OK, L"Restoring adapter mac=%ws (attempt %d)",
+                             mac.c_str(), attempt);
+                    ApplyAdapterConfig(adapters[i]);
+                    restored.insert(i);
+                    break;
+                }
+            }
+        }
+    }
+
     for (size_t i = 0; i < adapters.size(); i++)
     {
-        RestoreAdapter(adapters[i]);
+        if (!restored.count(i))
+        {
+            LogReport(S_OK, L"ERROR: adapter mac=%ws svc=%ws not restored "
+                     L"after %d attempts",
+                     adapters[i].mac_addr.c_str(),
+                     adapters[i].srvc_name.c_str(),
+                     RESTORE_MAX_RETRIES);
+        }
     }
 
     return true;

--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -474,31 +474,39 @@ bool ConfigRead::SetGateWays(AdapterConfig const& cfg, bool ipv4)
  */
 bool ConfigRead::ApplyAdapterConfig(AdapterConfig const& cfg)
 {
+    bool ok = true;
+
     if (!EnableStatic(cfg, true))
     {
         LogReport(S_OK, L"EnableStatic IPv4 failed");
+        ok = false;
     }
     if (!EnableStatic(cfg, false))
     {
         LogReport(S_OK, L"EnableStatic IPv6 failed");
+        ok = false;
     }
     if (!SetDNSServer(cfg))
     {
         LogReport(S_OK, L"SetDNSServer failed");
+        ok = false;
     }
     if (!SetGateWays(cfg, true))
     {
         LogReport(S_OK, L"SetGateWays IPv4 failed");
+        ok = false;
     }
     if (!SetGateWays(cfg, false))
     {
         LogReport(S_OK, L"SetGateWays IPv6 failed");
+        ok = false;
     }
     if (!EnableDNS(cfg))
     {
         LogReport(S_OK, L"EnableDNS failed");
+        ok = false;
     }
-    return true;
+    return ok;
 }
 
 bool ConfigRead::Run()
@@ -516,7 +524,7 @@ bool ConfigRead::Run()
         }
     }
 
-    LogReport(S_OK, L"Parsed %zu adapter(s) from config file", adapters.size());
+    LogReport(S_OK, L"Parsed %d adapter(s) from config file", (int)adapters.size());
 
     /*
      * Use a set of indices to track which adapters have been restored.
@@ -539,10 +547,10 @@ bool ConfigRead::Run()
     {
         if (attempt > 1)
         {
-            LogReport(S_OK, L"Attempt %d/%d: %zu adapter(s) pending, "
+            LogReport(S_OK, L"Attempt %d/%d: %d adapter(s) pending, "
                      L"waiting %lu ms for device re-enumeration",
                      attempt, RESTORE_MAX_RETRIES,
-                     adapters.size() - restored.size(),
+                     (int)(adapters.size() - restored.size()),
                      RESTORE_RETRY_DELAY_MS);
             Sleep(RESTORE_RETRY_DELAY_MS);
         }
@@ -563,8 +571,10 @@ bool ConfigRead::Run()
                 {
                     LogReport(S_OK, L"Restoring adapter mac=%ws (attempt %d)",
                              mac.c_str(), attempt);
-                    ApplyAdapterConfig(adapters[i]);
-                    restored.insert(i);
+                    if (ApplyAdapterConfig(adapters[i]))
+                    {
+                        restored.insert(i);
+                    }
                     break;
                 }
             }

--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -84,6 +84,8 @@ void Config::Close()
 
 bool ConfigWrite::Run()
 {
+    int saved = 0;
+
     if (nac->GetInstances())
     {
         while (nac->MoveNext())
@@ -95,28 +97,38 @@ bool ConfigWrite::Run()
             {
                 LogReport(S_OK, L"srvmane = %ws", srvname.c_str());
 
-                cf->WriteLine(STRING_FORMAT, MACADDR, VT_BSTR, nac->GetStringProperty(MACADDR).c_str());
-                cf->WriteLine(STRING_FORMAT, DESCR, VT_BSTR, nac->GetStringProperty(DESCR).c_str());
-//                cf->WriteLine(INTEGER_FORMAT, DHCPEN, VT_BOOL, nac->GetBoolProperty(DHCPEN));
-                cf->WriteLine(STRING_FORMAT, IPADDR, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(IPADDR).c_str());
-                cf->WriteLine(STRING_FORMAT, IPSUBNET, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(IPSUBNET).c_str());
-                cf->WriteLine(INTEGER_FORMAT, IPCONMET, VT_I4, nac->GetIntProperty(IPCONMET));
-                cf->WriteLine(STRING_FORMAT, DNSDOM, VT_BSTR, nac->GetStringProperty(DNSDOM).c_str());
-//                cf->WriteLine(INTEGER_FORMAT, IPEN, VT_BOOL, nac->GetBoolProperty(IPEN));
-                cf->WriteLine(STRING_FORMAT, DEFIPGW, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(DEFIPGW).c_str());
-                cf->WriteLine(INTEGER_FORMAT, IPFLTSECEN, VT_BOOL, nac->GetBoolProperty(IPFLTSECEN));
-                cf->WriteLine(STRING_FORMAT, DNSDMSUFSRCHORD, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(DNSDMSUFSRCHORD).c_str());
-                cf->WriteLine(STRING_FORMAT, DNSHOSTNAME, VT_BSTR, nac->GetStringProperty(DNSHOSTNAME).c_str());
-                cf->WriteLine(INTEGER_FORMAT, DNSWINSRES, VT_BOOL, nac->GetBoolProperty(DNSWINSRES));
-                cf->WriteLine(STRING_FORMAT, DNSSRCHORD, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(DNSSRCHORD).c_str());
-                cf->WriteLine(INTEGER_FORMAT, INDX, VT_I4, nac->GetIntProperty(INDX));
+                bool ok = true;
+                ok = cf->WriteLine(STRING_FORMAT, MACADDR, VT_BSTR, nac->GetStringProperty(MACADDR).c_str()) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, DESCR, VT_BSTR, nac->GetStringProperty(DESCR).c_str()) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, IPADDR, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(IPADDR).c_str()) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, IPSUBNET, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(IPSUBNET).c_str()) && ok;
+                ok = cf->WriteLine(INTEGER_FORMAT, IPCONMET, VT_I4, nac->GetIntProperty(IPCONMET)) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, DNSDOM, VT_BSTR, nac->GetStringProperty(DNSDOM).c_str()) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, DEFIPGW, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(DEFIPGW).c_str()) && ok;
+                ok = cf->WriteLine(INTEGER_FORMAT, IPFLTSECEN, VT_BOOL, nac->GetBoolProperty(IPFLTSECEN)) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, DNSDMSUFSRCHORD, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(DNSDMSUFSRCHORD).c_str()) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, DNSHOSTNAME, VT_BSTR, nac->GetStringProperty(DNSHOSTNAME).c_str()) && ok;
+                ok = cf->WriteLine(INTEGER_FORMAT, DNSWINSRES, VT_BOOL, nac->GetBoolProperty(DNSWINSRES)) && ok;
+                ok = cf->WriteLine(STRING_FORMAT, DNSSRCHORD, VT_ARRAY | VT_BSTR, nac->GetSafeArrayProperty(DNSSRCHORD).c_str()) && ok;
+                ok = cf->WriteLine(INTEGER_FORMAT, INDX, VT_I4, nac->GetIntProperty(INDX)) && ok;
                 // ServiceName must be last: ConfigRead::Run() uses it as the adapter block boundary
-                cf->WriteLine(STRING_FORMAT, SRVSNAME, VT_BSTR, srvname.c_str());
+                ok = cf->WriteLine(STRING_FORMAT, SRVSNAME, VT_BSTR, srvname.c_str()) && ok;
+
+                if (ok)
+                {
+                    saved++;
+                }
+                else
+                {
+                    LogReport(S_OK, L"ERROR: failed to write config for adapter mac=%ws",
+                             nac->GetStringProperty(MACADDR).c_str());
+                }
             }
         }
     }
 
-    return true;
+    LogReport(S_OK, L"Saved %d adapter config(s)", saved);
+    return (saved > 0);
 }
 
 ConfigRead::ConfigRead(const PCWSTR filename) : Config(filename)

--- a/src/DrvInst/DrvInstCA/ConfigClass.h
+++ b/src/DrvInst/DrvInstCA/ConfigClass.h
@@ -92,6 +92,32 @@ public:
     bool Run();
 };
 
+struct AdapterConfig
+{
+    std::vector<std::wstring> ipv4_addr;
+    std::vector<std::wstring> ipv4_subnet;
+    std::vector<std::wstring> ipv4_def_gw;
+    std::vector<std::wstring> ipv6_addr;
+    std::vector<std::wstring> ipv6_subnet;
+    std::vector<std::wstring> ipv6_def_gw;
+    std::vector<std::wstring> dns_dom_suff_srch_ord;
+    std::vector<std::wstring> dns_serv_srch_ord;
+
+    std::wstring mac_addr;
+    std::wstring descr;
+    std::wstring dns_dom;
+    std::wstring srvc_name;
+    std::wstring dns_host_name;
+
+    bool dhcp_en = false;
+    bool ip_en = false;
+    bool ip_filt_sec_en = false;
+    bool dns_for_wins_res_en = false;
+
+    unsigned int ip_conn_metr = 0;
+    unsigned int index = 0;
+};
+
 class ConfigRead : public Config
 {
 public:
@@ -110,35 +136,15 @@ protected:
     bool ProcessBoolean(std::vector<std::wstring>& vector);
     bool ProcessArrayOfStrings(std::vector<std::wstring>& vector);
     bool ProcessParametesAsVector(std::vector<std::wstring>& vector);
-    bool RestoreConfig();
+    bool RestoreAdapter(AdapterConfig const& cfg);
 private:
-    bool EnableStatic(bool ipv4 = true);
-    bool SetDNSServer(void);
-    bool SetGateWays(bool ipv4 = true);
-    bool EnableDNS(void);
+    bool EnableStatic(AdapterConfig const& cfg, bool ipv4 = true);
+    bool SetDNSServer(AdapterConfig const& cfg);
+    bool SetGateWays(AdapterConfig const& cfg, bool ipv4 = true);
+    bool EnableDNS(AdapterConfig const& cfg);
     bool BuildSafeArrayFromVector(SAFEARRAY** sa, std::vector<std::wstring> const& arr);
     bool IsValidIPv4Address(std::wstring const& address);
 protected:
-    std::vector<std::wstring> ipv4_addr;
-    std::vector<std::wstring> ipv4_subnet;
-    std::vector<std::wstring> ipv4_def_gw;
-    std::vector<std::wstring> ipv6_addr;
-    std::vector<std::wstring> ipv6_subnet;
-    std::vector<std::wstring> ipv6_def_gw;
-    std::vector<std::wstring> dns_dom_suff_srch_ord;
-    std::vector<std::wstring> dns_serv_srch_ord;
-
-    std::wstring mac_addr;
-    std::wstring descr;
-    std::wstring dns_dom;
-    std::wstring srvc_name;
-    std::wstring dns_host_name;
-
-    bool dhcp_en;
-    bool ip_en;
-    bool ip_filt_sec_en;
-    bool dns_for_wins_res_en;
-
-    unsigned int ip_conn_metr;
-    unsigned int index;
+    AdapterConfig cur;
+    std::vector<AdapterConfig> adapters;
 };

--- a/src/DrvInst/DrvInstCA/ConfigClass.h
+++ b/src/DrvInst/DrvInstCA/ConfigClass.h
@@ -136,7 +136,7 @@ protected:
     bool ProcessBoolean(std::vector<std::wstring>& vector);
     bool ProcessArrayOfStrings(std::vector<std::wstring>& vector);
     bool ProcessParametesAsVector(std::vector<std::wstring>& vector);
-    bool RestoreAdapter(AdapterConfig const& cfg);
+    bool ApplyAdapterConfig(AdapterConfig const& cfg);
 private:
     bool EnableStatic(AdapterConfig const& cfg, bool ipv4 = true);
     bool SetDNSServer(AdapterConfig const& cfg);

--- a/src/DrvInst/DrvInstCA/ManagementClass.cpp
+++ b/src/DrvInst/DrvInstCA/ManagementClass.cpp
@@ -48,6 +48,15 @@ bool ManagementClass::GetInstances()
 {
     HRESULT hr;
 
+    /* Release any previous state so GetInstances() can be called
+     * multiple times safely (e.g., during retry loops). CComPtr
+     * asserts that the pointer is NULL in operator&(), so we must
+     * explicitly release before re-initializing. */
+    m_pclsObj.Release();
+    m_pEnumerator.Release();
+    m_pSvc.Release();
+    m_pLoc.Release();
+
     if (m_bSecurity == false)
     {
         hr = CoInitializeSecurity(


### PR DESCRIPTION
## Problem

After a virtio-win driver upgrade, the NIC may briefly disappear during PnP device re-enumeration. If `RestoreSettings` runs before the adapter reappears in WMI, the saved static IP configuration is silently lost — the adapter comes back with APIPA (169.254.x.x) instead of the configured static IP.

This is a race condition between PnP device re-enumeration (asynchronous) and the MSI custom action that restores the network configuration (synchronous, runs immediately after driver install). Customers report this as a rare but impactful failure — the VM loses network connectivity after a routine driver upgrade.

## Root Cause

`RestoreAdapter()` performs a single WMI query (`Win32_NetworkAdapterConfiguration`) to find the adapter by MAC address. If the adapter hasn't re-enumerated yet, the query returns no match and the function returns `false` without any retry or diagnostic logging. The config file has the correct data, but the target adapter doesn't exist in WMI at that moment.

## Fix

Restructure the restore flow in `ConfigRead::Run()`:

- Move the WMI adapter lookup from `RestoreAdapter()` into `Run()`, which now owns the retry loop
- Retry the WMI enumeration up to 5 times with 3-second delays (15s total) to allow PnP to complete device re-enumeration
- Each WMI enumeration pass matches all pending adapters in a single forward scan — no redundant queries for already-restored adapters
- Use `std::set<size_t>` to track restored adapter indices (`set::count()` is always safe, unlike a parallel `bool` vector that could go out of bounds)
- Log each retry attempt and report any adapters that could not be restored after all attempts
- Rename `RestoreAdapter()` to `ApplyAdapterConfig()` — it no longer does the WMI lookup, only applies EnableStatic/DNS/GW settings

`GetInstances()` is safe to call multiple times: all WMI handles (`m_pLoc`, `m_pSvc`, `m_pEnumerator`) are `CComPtr` smart pointers — reassignment releases the previous COM object automatically.

## Testing

Tested on Windows Server 2025 (build 26100.1742) with e1000 (management) + virtio-net-pci (test NIC, static IP 192.168.100.50/24).

**Reproduction:** `pnputil /remove-device` on the VirtIO NIC followed by a delayed `pnputil /scan-devices` (5s), forcing a full PnP re-enumeration cycle.

| Test | Retry | Result | Detail |
|------|-------|--------|--------|
| Baseline | MaxRetries=1 | **FAIL** | Adapter not found, IP lost (169.254.x.x APIPA) |
| With retry | MaxRetries=5, 3s delay | **PASS** | Adapter found on attempt 4 (~10s), IP restored to 192.168.100.50/24 |

MSI log output with retry enabled:
```
Attempt 2/5: 1 adapter(s) pending, waiting 3000 ms for device re-enumeration
Attempt 3/5: 1 adapter(s) pending, waiting 3000 ms for device re-enumeration
Attempt 4: matched adapter MAC=52:54:00:12:34:57
EnableStatic: return=0
SetGateways: return=0
SetDNSServerSearchOrder: return=0
```

**Note on reproduction fidelity:** In our testing, the standard MSI upgrade path (`pnputil /add-driver /install`) performs an in-place driver update that preserves the adapter identity and static IP without any retry needed. The reproduction uses `pnputil /remove-device` + `/scan-devices` to force a full device re-enumeration, which is a more aggressive scenario. Customer reports suggest this race occurs in specific environments — possibly related to slow storage, concurrent PnP activity, or specific version transitions that trigger a full device re-enumeration rather than an in-place update. The retry logic is a defensive measure that also improves diagnostic logging — unrestored adapters are now explicitly reported in the MSI log.

## Depends on

PR #91 (Fix NIC config restore for multiple VirtIO adapters) — this patch applies on top of the `AdapterConfig` struct and per-adapter restore introduced there.
