### PR TITLE
RHEL-180730: Fix heap corruption crashes in MSI custom actions

### DIFF
--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -311,6 +311,8 @@ bool ConfigRead::BuildSafeArrayFromVector(SAFEARRAY** sa, std::vector<std::wstri
             hr = SafeArrayPutElement(param1_list, idx, (BSTR)bstr_t(arr[i].c_str()));
             if (FAILED(hr))
             {
+                SafeArrayDestroy(param1_list);
+                *sa = nullptr;
                 return (false);
             }
         }
@@ -318,6 +320,7 @@ bool ConfigRead::BuildSafeArrayFromVector(SAFEARRAY** sa, std::vector<std::wstri
         *sa = param1_list;
         return true;
     }
+    *sa = nullptr;
     return false;
 }
 
@@ -357,11 +360,16 @@ bool ConfigRead::EnableStatic(AdapterConfig const& cfg, bool ipv4)
             var2.vt = VT_EMPTY;
             var2.parray = nullptr;
             SafeArrayDestroy(sa1);
+            sa1 = nullptr;
             SafeArrayDestroy(sa2);
+            sa2 = nullptr;
             return result;
         }
         if (sa1)
+        {
             SafeArrayDestroy(sa1);
+            sa1 = nullptr;
+        }
     }
     return false;
 }
@@ -394,6 +402,7 @@ bool ConfigRead::SetDNSServer(AdapterConfig const& cfg)
             var1.vt = VT_EMPTY;
             var1.parray = nullptr;
             SafeArrayDestroy(sa1);
+            sa1 = nullptr;
             return result;
         }
     }
@@ -447,11 +456,16 @@ bool ConfigRead::EnableDNS(AdapterConfig const& cfg)
             var4.vt = VT_EMPTY;
             var4.parray = nullptr;
             SafeArrayDestroy(sa1);
+            sa1 = nullptr;
             SafeArrayDestroy(sa2);
+            sa2 = nullptr;
             return result;
         }
         if (sa1)
+        {
             SafeArrayDestroy(sa1);
+            sa1 = nullptr;
+        }
     }
 
     return false;
@@ -485,6 +499,7 @@ bool ConfigRead::SetGateWays(AdapterConfig const& cfg, bool ipv4)
             var1.vt = VT_EMPTY;
             var1.parray = nullptr;
             SafeArrayDestroy(sa1);
+            sa1 = nullptr;
             return result;
         }
     }

--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -422,13 +422,8 @@ bool ConfigRead::EnableDNS(AdapterConfig const& cfg)
         if (BuildSafeArrayFromVector(&sa1, cfg.dns_serv_srch_ord) &&
             BuildSafeArrayFromVector(&sa2, cfg.dns_dom_suff_srch_ord))
         {
-            CComVariant var1;
-            var1.vt = VT_BSTR;
-            var1.bstrVal = SysAllocString(cfg.dns_host_name.c_str());
-
-            CComVariant var2;
-            var2.vt = VT_BSTR;
-            var2.bstrVal = SysAllocString(cfg.dns_dom.c_str());
+            CComVariant var1(cfg.dns_host_name.c_str());
+            CComVariant var2(cfg.dns_dom.c_str());
 
             CComVariant var3;
             var3.vt = VT_ARRAY | VT_BSTR;

--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -324,6 +324,7 @@ bool ConfigRead::BuildSafeArrayFromVector(SAFEARRAY** sa, std::vector<std::wstri
 bool ConfigRead::EnableStatic(AdapterConfig const& cfg, bool ipv4)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
+    bool result = false;
 
     if (nac->GetMethod(ENSTATIC_METHOD, pInInstClass))
     {
@@ -348,10 +349,19 @@ bool ConfigRead::EnableStatic(AdapterConfig const& cfg, bool ipv4)
                     {
                         LogReport(S_OK, L"%ws method completed with the error code %d", ENSTATIC_METHOD, ret);
                     }
-                    return true;
+                    result = true;
                 }
             }
+            var1.vt = VT_EMPTY;
+            var1.parray = nullptr;
+            var2.vt = VT_EMPTY;
+            var2.parray = nullptr;
+            SafeArrayDestroy(sa1);
+            SafeArrayDestroy(sa2);
+            return result;
         }
+        if (sa1)
+            SafeArrayDestroy(sa1);
     }
     return false;
 }
@@ -359,6 +369,7 @@ bool ConfigRead::EnableStatic(AdapterConfig const& cfg, bool ipv4)
 bool ConfigRead::SetDNSServer(AdapterConfig const& cfg)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
+    bool result = false;
 
     if (nac->GetMethod(SETDNSSRCORD_METHOD, pInInstClass))
     {
@@ -377,9 +388,13 @@ bool ConfigRead::SetDNSServer(AdapterConfig const& cfg)
                     {
                         LogReport(S_OK, L"%ws method completed with the error code %d", SETDNSSRCORD_METHOD, ret);
                     }
-                    return true;
+                    result = true;
                 }
             }
+            var1.vt = VT_EMPTY;
+            var1.parray = nullptr;
+            SafeArrayDestroy(sa1);
+            return result;
         }
     }
 
@@ -389,6 +404,7 @@ bool ConfigRead::SetDNSServer(AdapterConfig const& cfg)
 bool ConfigRead::EnableDNS(AdapterConfig const& cfg)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
+    bool result = false;
 
     if (nac->GetMethod(ENDNS_METHOD, pInInstClass))
     {
@@ -399,11 +415,11 @@ bool ConfigRead::EnableDNS(AdapterConfig const& cfg)
         {
             CComVariant var1;
             var1.vt = VT_BSTR;
-            var1.bstrVal = (BSTR)bstr_t(cfg.dns_host_name.c_str());
+            var1.bstrVal = SysAllocString(cfg.dns_host_name.c_str());
 
             CComVariant var2;
             var2.vt = VT_BSTR;
-            var2.bstrVal = (BSTR)bstr_t(cfg.dns_dom.c_str());
+            var2.bstrVal = SysAllocString(cfg.dns_dom.c_str());
 
             CComVariant var3;
             var3.vt = VT_ARRAY | VT_BSTR;
@@ -423,10 +439,19 @@ bool ConfigRead::EnableDNS(AdapterConfig const& cfg)
                     {
                         LogReport(S_OK, L"%ws method completed with the error code %d", ENDNS_METHOD, ret);
                     }
-                    return true;
+                    result = true;
                 }
             }
+            var3.vt = VT_EMPTY;
+            var3.parray = nullptr;
+            var4.vt = VT_EMPTY;
+            var4.parray = nullptr;
+            SafeArrayDestroy(sa1);
+            SafeArrayDestroy(sa2);
+            return result;
         }
+        if (sa1)
+            SafeArrayDestroy(sa1);
     }
 
     return false;
@@ -435,6 +460,7 @@ bool ConfigRead::EnableDNS(AdapterConfig const& cfg)
 bool ConfigRead::SetGateWays(AdapterConfig const& cfg, bool ipv4)
 {
     CComPtr<IWbemClassObject> pInInstClass = nullptr;
+    bool result = false;
 
     if (nac->GetMethod(SETGW_METHOD, pInInstClass))
     {
@@ -453,9 +479,13 @@ bool ConfigRead::SetGateWays(AdapterConfig const& cfg, bool ipv4)
                     {
                         LogReport(S_OK, L"%ws method completed with the error code %d", SETGW_METHOD, ret);
                     }
-                    return true;
+                    result = true;
                 }
             }
+            var1.vt = VT_EMPTY;
+            var1.parray = nullptr;
+            SafeArrayDestroy(sa1);
+            return result;
         }
     }
 

--- a/src/DrvInst/DrvInstCA/DevProps.cpp
+++ b/src/DrvInst/DrvInstCA/DevProps.cpp
@@ -373,28 +373,30 @@ void DevProps::ObtainDevHWIDs()
 
 const wchar_t* GetErrorString(DWORD Error)
 {
-    std::wstring msg;
+    static thread_local wchar_t buf[ERR_BUF_SIZE];
 
     LPWSTR msgbuf = nullptr;
-    FormatMessage(
+    DWORD len = FormatMessage(
         FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
         nullptr,
         Error,
         0,
-        (LPWSTR)msgbuf,
-        0,//MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
+        (LPWSTR)&msgbuf,
+        0,
         nullptr);
-    if (msgbuf != nullptr)
+    if (len > 0 && msgbuf != nullptr)
     {
-        msg = msgbuf;
+        wcsncpy_s(buf, ERR_BUF_SIZE, msgbuf, _TRUNCATE);
         LocalFree(msgbuf);
     }
     else
     {
-        msg = L"Unknown error";
+        if (msgbuf != nullptr)
+            LocalFree(msgbuf);
+        wcscpy_s(buf, ERR_BUF_SIZE, L"Unknown error");
     }
 
-    return msg.c_str();
+    return buf;
 }
 
 const wchar_t* DevProps::GetFullPath()


### PR DESCRIPTION
## Summary

- Fix CComVariant/SAFEARRAY ownership bug that crashes RestoreSettings CA process during MSI upgrade
- Fix GetErrorString returning dangling pointer to freed memory, producing "Unknown error" instead of actual error messages

## Problem

MSI upgrade logs show the CA process dying:

```
RestoreSettings:  Virtio-Win Installer Restoring adapter mac=52:54:00:12:34:57 (attempt 1)
MSI (s) (04:B0) [20:13:23:741]: Lost connection to custom action server process.
```

Error messages always show "Unknown error":

```
UninstallPackages:  Error 0x80070003: ... err = 0x3: Unknown error
```

## Root causes

**1. CComVariant/SAFEARRAY ownership (ConfigClass.cpp)**

`BuildSafeArrayFromVector` creates a SAFEARRAY assigned to `CComVariant.parray`. When `CComVariant` destructs, `VariantClear` frees the SAFEARRAY and its BSTR elements. In `EnableDNS`, `(BSTR)bstr_t(str.c_str())` assigns a temporary's BSTR to `CComVariant.bstrVal` — dangling pointer after end-of-statement.

**2. GetErrorString dangling pointer (DevProps.cpp)**

Returns `msg.c_str()` of a destroyed local `std::wstring`. `FormatMessage` called with `(LPWSTR)msgbuf` instead of `(LPWSTR)&msgbuf` — never resolved error codes.

## Test results

All tests on **fresh VM clones** with page heap enabled (`gflags /p /enable msiexec.exe /full`). Upgrade path: pnputil 1.9.44 → MSI 1.9.50 → MSI 1.9.57. Both MSI DLL binaries patched (`ConfManagementDll` + `DrvInstallDll`). Built from source using MSBuild + EWDK.

| Test | DLL source | Page heap crashes |
|------|-----------|-------------------|
| Pre-built MSIs (original from brew) | shipped binaries | **6** |
| Upstream master (rebuilt from source) | MSBuild, no fixes | **4** |
| GetErrorString fix only | MSBuild, DevProps.cpp | **2** |
| **Both fixes** | **MSBuild, DevProps.cpp + ConfigClass.cpp** | **0** |

### Note on MSI binary table

The MSI contains two copies of the CA DLL:
- `ConfManagementDll` — used by Save/RestoreSettings
- `DrvInstallDll` — used by Install/UninstallPackages

Both contain the same code and both are affected by these bugs. The test results above reflect patching both binaries.