### PR TITLE
RHEL-180685: Add retry logic for NIC config restore after driver update

### DIFF
--- a/src/DrvInst/DrvInstCA/ConfigClass.cpp
+++ b/src/DrvInst/DrvInstCA/ConfigClass.cpp
@@ -28,6 +28,10 @@
  */
 #include "stdafx.h"
 #include "ConfigClass.h"
+#include <set>
+
+static const int RESTORE_MAX_RETRIES = 5;
+static const DWORD RESTORE_RETRY_DELAY_MS = 3000;
 
 Config::Config(const PCWSTR filename)
 {
@@ -502,47 +506,27 @@ bool ConfigRead::SetGateWays(AdapterConfig const& cfg, bool ipv4)
     return false;
 }
 
-bool ConfigRead::RestoreAdapter(AdapterConfig const& cfg)
+bool ConfigRead::ApplyAdapterConfig(AdapterConfig const& cfg)
 {
-    if (nac->GetInstances())
-    {
-        while (nac->MoveNext())
-        {
-            std::wstring mac = nac->GetStringProperty(MACADDR);
-            LogReport(S_OK, L"macs %ws <--> %ws.", mac.c_str(), cfg.mac_addr.c_str());
-            if (mac == cfg.mac_addr &&
-                nac->GetStringProperty(SRVSNAME) == cfg.srvc_name)
-            {
-                if (!EnableStatic(cfg, true))
-                {
-                    LogReport(S_OK, L"EnableStatic IPv4 failed");
-                }
-                if (!EnableStatic(cfg, false))
-                {
-                    LogReport(S_OK, L"EnableStatic IPv6 failed");
-                }
-                if (!SetDNSServer(cfg))
-                {
-                    LogReport(S_OK, L"SetDNSServer failed");
-                }
-                if (!SetGateWays(cfg, true))
-                {
-                    LogReport(S_OK, L"SetGateWays IPv4 failed");
-                }
-                if (!SetGateWays(cfg, false))
-                {
-                    LogReport(S_OK, L"SetGateWays IPv6 failed");
-                }
-                if (!EnableDNS(cfg))
-                {
-                    LogReport(S_OK, L"EnableDNS failed");
-                }
-                return true;
-            }
-        }
-    }
+    if (!cfg.ipv4_addr.empty() && !EnableStatic(cfg, true))
+        LogReport(S_OK, L"EnableStatic IPv4 failed");
 
-    return false;
+    if (!cfg.ipv6_addr.empty() && !EnableStatic(cfg, false))
+        LogReport(S_OK, L"EnableStatic IPv6 failed");
+
+    if (!cfg.dns_serv_srch_ord.empty() && !SetDNSServer(cfg))
+        LogReport(S_OK, L"SetDNSServer failed");
+
+    if (!cfg.ipv4_def_gw.empty() && !SetGateWays(cfg, true))
+        LogReport(S_OK, L"SetGateWays IPv4 failed");
+
+    if (!cfg.ipv6_def_gw.empty() && !SetGateWays(cfg, false))
+        LogReport(S_OK, L"SetGateWays IPv6 failed");
+
+    if (!cfg.dns_serv_srch_ord.empty() && !cfg.dns_dom_suff_srch_ord.empty() && !EnableDNS(cfg))
+        LogReport(S_OK, L"EnableDNS failed");
+
+    return true;
 }
 
 bool ConfigRead::Run()
@@ -560,9 +544,60 @@ bool ConfigRead::Run()
         }
     }
 
+    LogReport(S_OK, L"Parsed %d adapter(s) from config file", (int)adapters.size());
+
+    std::set<size_t> restored;
+
+    for (int attempt = 1;
+         attempt <= RESTORE_MAX_RETRIES && restored.size() < adapters.size();
+         attempt++)
+    {
+        if (attempt > 1)
+        {
+            LogReport(S_OK, L"Attempt %d/%d: %d adapter(s) pending, "
+                     L"waiting %lu ms for device re-enumeration",
+                     attempt, RESTORE_MAX_RETRIES,
+                     (int)(adapters.size() - restored.size()),
+                     RESTORE_RETRY_DELAY_MS);
+            Sleep(RESTORE_RETRY_DELAY_MS);
+        }
+
+        if (!nac->GetInstances())
+            continue;
+
+        while (nac->MoveNext())
+        {
+            std::wstring mac = nac->GetStringProperty(MACADDR);
+            std::wstring svc = nac->GetStringProperty(SRVSNAME);
+
+            for (size_t i = 0; i < adapters.size(); i++)
+            {
+                if (restored.count(i))
+                    continue;
+                if (mac == adapters[i].mac_addr && svc == adapters[i].srvc_name)
+                {
+                    LogReport(S_OK, L"Restoring adapter mac=%ws (attempt %d)",
+                             mac.c_str(), attempt);
+                    if (ApplyAdapterConfig(adapters[i]))
+                    {
+                        restored.insert(i);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
     for (size_t i = 0; i < adapters.size(); i++)
     {
-        RestoreAdapter(adapters[i]);
+        if (!restored.count(i))
+        {
+            LogReport(S_OK, L"ERROR: adapter mac=%ws svc=%ws not restored "
+                     L"after %d attempts",
+                     adapters[i].mac_addr.c_str(),
+                     adapters[i].srvc_name.c_str(),
+                     RESTORE_MAX_RETRIES);
+        }
     }
 
     return true;

--- a/src/DrvInst/DrvInstCA/ConfigClass.h
+++ b/src/DrvInst/DrvInstCA/ConfigClass.h
@@ -136,7 +136,7 @@ protected:
     bool ProcessBoolean(std::vector<std::wstring>& vector);
     bool ProcessArrayOfStrings(std::vector<std::wstring>& vector);
     bool ProcessParametesAsVector(std::vector<std::wstring>& vector);
-    bool RestoreAdapter(AdapterConfig const& cfg);
+    bool ApplyAdapterConfig(AdapterConfig const& cfg);
 private:
     bool EnableStatic(AdapterConfig const& cfg, bool ipv4 = true);
     bool SetDNSServer(AdapterConfig const& cfg);

--- a/src/DrvInst/DrvInstCA/ManagementClass.cpp
+++ b/src/DrvInst/DrvInstCA/ManagementClass.cpp
@@ -48,6 +48,11 @@ bool ManagementClass::GetInstances()
 {
     HRESULT hr;
 
+    m_pclsObj.Release();
+    m_pEnumerator.Release();
+    m_pSvc.Release();
+    m_pLoc.Release();
+
     if (m_bSecurity == false)
     {
         hr = CoInitializeSecurity(


### PR DESCRIPTION
## Problem

After a virtio-win driver upgrade, the NIC may briefly disappear during PnP device re-enumeration. If `RestoreSettings` runs before the adapter reappears in WMI, the MAC address lookup fails silently and the saved static IP configuration is lost — the adapter comes back with APIPA (169.254.x.x) instead of the configured static address.

This is a race condition between asynchronous PnP device re-enumeration and the synchronous MSI custom action that restores network configuration. Customers report this as a rare but impactful failure — the VM loses network connectivity after a routine driver upgrade.

## Root Cause

`RestoreAdapter()` performs a single WMI query (`Win32_NetworkAdapterConfiguration`) to find the adapter by MAC address. If the adapter hasn't re-enumerated yet, the query returns no match and the function returns `false` without retry or diagnostic logging.

## Fix

- Move the WMI adapter lookup from `RestoreAdapter()` into `ConfigRead::Run()`, which now owns a retry loop
- Retry WMI enumeration up to 5 times with 3-second delays (15 seconds total) to allow PnP to complete device re-enumeration
- Each attempt scans all WMI results in a single forward pass and matches against all adapters not yet restored — no redundant queries
- Track restored adapters with `std::set<size_t>` (safe regardless of collection size, unlike a parallel bool vector)
- Log each retry attempt and report any adapters that remain unrestored after all attempts
- Rename `RestoreAdapter()` to `ApplyAdapterConfig()` — it now only applies EnableStatic/DNS/GW settings without doing WMI lookups
- Guard each WMI operation in `ApplyAdapterConfig()` — skip operations with empty config data (e.g. no gateway, no IPv6 addresses) rather than calling the WMI wrapper and getting a false failure
- Add explicit `Release()` calls in `ManagementClass::GetInstances()` so it is safe to call multiple times in the retry loop

`GetInstances()` is safe to call repeatedly: all WMI handles (`m_pLoc`, `m_pSvc`, `m_pEnumerator`) are `CComPtr` smart pointers — reassignment releases the previous COM object automatically.

## Testing

**Environment:** Windows Server 2025 (build 26100.1742), QEMU/KVM Q35, e1000 (management) + 2x virtio-net-pci (netkvm, static IPs).

### Test 1: Full MSI upgrade path

Upgrade path: pnputil base install (1.9.44) → MSI 1.9.50 → patched MSI 1.9.57.

NIC configuration:
- NIC1 (MAC :57): 192.168.100.50/24, DNS 8.8.8.8, no gateway
- NIC2 (MAC :58): 192.168.100.60 + .61 (dual IP), gateway 192.168.100.1, DNS 8.8.8.8 + 1.1.1.1

| Step | NIC1 IP | NIC2 IPs | NIC2 GW | NIC2 DNS | Result |
|------|---------|----------|---------|----------|--------|
| After MSI 1.9.50 | .50 | .60, .61 | .1 | 8.8.8.8 | PASS |
| After patched MSI 1.9.57 | .50 | .60, .61 | .1 | 8.8.8.8 | PASS |

MSI log (step 2):
```
Parsed 2 adapter(s) from config file
Restoring adapter mac=52:54:00:12:34:57 (attempt 1)
Restoring adapter mac=52:54:00:12:34:58 (attempt 1)
```

Both adapters found and restored on attempt 1. No ERROR lines, no spurious retries.

### Test 2: Forced race condition (retry verification)

Reproduction method: `pnputil /remove-device` removes the VirtIO NIC, then `pnputil /scan-devices` runs after a 5-second delay to simulate delayed PnP re-enumeration. A PowerShell script mirrors the exact WMI flow (SaveSettings → device removal → RestoreSettings with configurable retry → rescan → verify).

| Test | MaxRetries | Result | Detail |
|------|-----------|--------|--------|
| Baseline (no retry) | 1 | **FAIL** | Adapter not found in WMI, IP lost (169.254.x.x APIPA) |
| With retry | 5 | **PASS** | Adapter found on attempt 4 (~10s), static IP restored to 192.168.100.50/24 |

DLL built from vcxproj using EWDK (MSBuild, Release|x64, 0 warnings). Both MSI binary entries (`ConfManagementDll` + `DrvInstallDll`) patched and verified.

## Depends on

- ~~PR #91 (Fix NIC config restore for multiple VirtIO adapters)~~ merged
- ~~PR #94 (Fix heap corruption crashes in MSI custom actions)~~ merged